### PR TITLE
remove the math sources from the response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ lockfile
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+*.swp
+tags

--- a/engine/mwsengine/handler.go
+++ b/engine/mwsengine/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/MathWebSearch/mwsapi/connection"
 	"github.com/MathWebSearch/mwsapi/engine"
 	"github.com/MathWebSearch/mwsapi/query"
+	"github.com/MathWebSearch/mwsapi/result"
 	"github.com/pkg/errors"
 )
 
@@ -87,7 +88,16 @@ func (handler *MWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (co
 	if request.Count {
 		res, err = Count(handler.connection, request.MWSQuery)
 	} else {
-		res, err = Run(handler.connection, request.MWSQuery, request.From, request.Size)
+        res, err = Run(handler.connection, request.MWSQuery, request.From, request.Size)
+        if(!request.Complete){
+            // remove the math source when requested
+            i,ok := res.(*result.Result)
+            if(ok){
+                for _, hit := range i.Hits {
+                    hit.Element.MathSource = nil
+                }
+            }
+        }
 	}
 
 	// if there was an error, wrap it and set the status code
@@ -99,6 +109,7 @@ func (handler *MWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (co
 	return
 }
 
+
 // MaxRequestSize is the maximum request size supported by the api
 const MaxRequestSize = 100
 
@@ -109,6 +120,7 @@ type MWSAPIRequest struct {
 	Count bool  `json:"count,omitempty"`
 	From  int64 `json:"from,omitempty"`
 	Size  int64 `json:"size,omitempty"`
+    Complete bool `json:"complete,omitempty"`
 }
 
 // Validate validates an MWSAPI Request

--- a/engine/mwsengine/run.go
+++ b/engine/mwsengine/run.go
@@ -65,6 +65,11 @@ func runRaw(conn *connection.MWSConnection, q *query.RawMWSQuery) (res *result.R
 	}
 	err = res.UnmarshalMWS(resp)
 	err = errors.Wrap(err, "res.UnmarshalMWS failed")
+    // remove all MathSource elements to make the response a little more lightweight
+    // maybe make this optional in the future?
+    for _, hit := range res.Hits {
+        hit.Element.MathSource = nil
+    }
 
 	return
 }

--- a/engine/mwsengine/run.go
+++ b/engine/mwsengine/run.go
@@ -26,6 +26,7 @@ func Run(conn *connection.MWSConnection, query *query.MWSQuery, from int64, size
 	// TODO: Paralellize this with appropriate page size
 	res, err = runRaw(conn, query.Raw(from, size))
 	err = errors.Wrap(err, "runRaw failed")
+
 	return
 }
 
@@ -65,11 +66,6 @@ func runRaw(conn *connection.MWSConnection, q *query.RawMWSQuery) (res *result.R
 	}
 	err = res.UnmarshalMWS(resp)
 	err = errors.Wrap(err, "res.UnmarshalMWS failed")
-    // remove all MathSource elements to make the response a little more lightweight
-    // maybe make this optional in the future?
-    for _, hit := range res.Hits {
-        hit.Element.MathSource = nil
-    }
 
 	return
 }


### PR DESCRIPTION
I hope this fixes the problem of really large responses of the daemon by removing the mathsources from the response, in my local test with a really small subset of the nlabharvests it reduced the size by round about factor 10